### PR TITLE
Fix IO blocking caused by static path & os.walk

### DIFF
--- a/custom_components/fontawesome/__init__.py
+++ b/custom_components/fontawesome/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from homeassistant.components.frontend import add_extra_js_url
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.http.view import HomeAssistantView
 
 from homeassistant.helpers import config_validation as cv
@@ -47,30 +48,42 @@ class ListingView(HomeAssistantView):
 
 
 async def async_setup(hass, config):
-    hass.http.register_static_path(
-            LOADER_URL,
-            hass.config.path(LOADER_PATH),
-            True
-        )
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                LOADER_URL,
+                hass.config.path(LOADER_PATH),
+                True
+            )
+        ]
+    )
     add_extra_js_url(hass, LOADER_URL)
 
     for iset in ["brands", "regular", "solid"]:
-        hass.http.register_static_path(
-                ICONS_URL + "/" + iset,
-                hass.config.path(ICONS_PATH + "/" + iset),
-                True
-            )
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    ICONS_URL + "/" + iset,
+                    hass.config.path(ICONS_PATH + "/" + iset),
+                    True
+                )
+            ]
+        )
         hass.http.register_view(
                 ListingView(
                     ICONLIST_URL + "/" + iset,
                     hass.config.path(ICONS_PATH + "/" + iset)
                 )
             )
-    hass.http.register_static_path(
-            CUSTOM_ICONS_URL,
-            hass.config.path(CUSTOM_ICONS_PATH),
-            True
-        )
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                CUSTOM_ICONS_URL,
+                hass.config.path(CUSTOM_ICONS_PATH),
+                True
+            )
+        ]
+    )
     hass.http.register_view(
             ListingView(
                 ICONLIST_URL + "/pro",


### PR DESCRIPTION
### Static Path

* Use `async_register_static_paths` instead of `register_static_path` as users will begin to receive warnings that it does blocking I/O in the event loop and the function itself will be deprecated in HA 2025.7.

### Registering View
* The `register_view` function now also passes the `hass` object so that it can be utilized to call the `async_add_executor_job` function within ListingView's `get` function - more on that below.

### Walk I/O blocking
The OS `walk` function [does blocking disk I/O](https://developers.home-assistant.io/docs/asyncio_blocking_operations/#walk) and users will get warnings about this. To get around this, we can use `hass.async_add_executor_job` to call it. However, this doesn't fully solve the problem since `walk` also calls `scandir` within itself, resulting in Home Assistant complaining about blocking still occurring. To get around this, I have added a `get_icons_list` helper function which is run in the executor instead of directly calling `walk` in the executor.

### Associated Issues
* Closes #86 