### PR TITLE
Add async_migrate_entry function

### DIFF
--- a/custom_components/fontawesome/__init__.py
+++ b/custom_components/fontawesome/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.components.http import StaticPathConfig
@@ -94,4 +95,17 @@ async def async_setup_entry(hass, entry):
 
 
 async def async_remove_entry(hass, entry):
+    return True
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+
+    if entry.version == 1:
+        entry.version = 2
+
+        hass.config_entries.async_update_entry(
+            entry,
+            title="Fontawesome Icons"
+        )
+        LOGGER.info("Migrating fontawesome config entry.")
     return True


### PR DESCRIPTION
### Description
Added `async_migrate_entry` function that will migrate the config entry for users that had fontawesome installed prior to the most recent update. During migration, the config entry will get set to `version 2` and a title of `Fontawesome Icons` added to reflect the changes you recently made to the config flow.

### Associated Issues
* Closes #89 