### PR TITLE
FIX: use async_update_entry instead of directly changing property

### DIFF
--- a/custom_components/fontawesome/__init__.py
+++ b/custom_components/fontawesome/__init__.py
@@ -101,11 +101,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
 
     if entry.version == 1:
-        entry.version = 2
-
         hass.config_entries.async_update_entry(
             entry,
-            title="Fontawesome Icons"
+            title="Fontawesome Icons", 
+            version = 2
         )
         LOGGER.info("Migrating fontawesome config entry.")
     return True


### PR DESCRIPTION
From Homeassistant 24.09 directly changing config attributes is not allowed anymore. 
The entries must be modified using async_update_entry() 
Source: <https://developers.home-assistant.io/blog/2024/02/12/async_update_entry/>

This fixes #91